### PR TITLE
Resolve NN and PMM estimator issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ nonprobsvy News and Updates
 + fixed the NN mass-imputation `k = 1` path by avoiding dimension drop errors and using leave-one-out matching for the non-probability variance proxy (closes #92)
 + fixed `nn_exact_se = TRUE` so the mini-bootstrap uses bootstrap-specific nearest-neighbor matches instead of reusing the original donor matches (closes #91)
 + fixed PMM `pmm_k_choice = "min_var"` so the best `k` found so far is returned instead of the first non-improving `k` (closes #93)
-+ fixed `nonprob_mi()` model-frame construction to pass `case_weights` instead of an undefined `weights` symbol (closes #99)
++ fixed `nonprob_mi()` model-frame construction to pass `case_weights` instead of an undefined internal `weights` symbol; this is a plumbing fix and does not otherwise change current case-weight semantics (closes #99)
 + reused nearest-neighbor search results across outcomes for multi-outcome NN mass-imputation fits (closes #104)
 + randomized equal-distance nearest-neighbor tie handling before donor aggregation, including exact small-grid tie handling at the distance cutoff (closes #105)
 + changed PMM `pmm_k_choice = "min_var"` to perform a full search over the candidate `k` grid rather than stopping at the first non-improving value (closes #106)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ nonprobsvy News and Updates
 + fixed the NN mass-imputation `k = 1` path by avoiding dimension drop errors and using leave-one-out matching for the non-probability variance proxy (closes #92)
 + fixed `nn_exact_se = TRUE` so the mini-bootstrap uses bootstrap-specific nearest-neighbor matches instead of reusing the original donor matches (closes #91)
 + fixed PMM `pmm_k_choice = "min_var"` so the best `k` found so far is returned instead of the first non-improving `k` (closes #93)
++ fixed `nonprob_mi()` model-frame construction to pass `case_weights` instead of an undefined `weights` symbol (closes #99)
++ reused nearest-neighbor search results across outcomes for multi-outcome NN mass-imputation fits (closes #104)
++ randomized equal-distance nearest-neighbor tie handling before donor aggregation, including exact small-grid tie handling at the distance cutoff (closes #105)
++ changed PMM `pmm_k_choice = "min_var"` to perform a full search over the candidate `k` grid rather than stopping at the first non-improving value (closes #106)
++ aligned NN and PMM point estimates and probability-side analytic variances with known-`N` Horvitz-Thompson means when `pop_size` is supplied (closes #107)
++ updated NN/PMM function documentation for known-`N` means, leave-one-out NN variance proxy, weighted mini-bootstrap, random tie handling, and full-grid PMM `k` selection (closes #108)
 + added regression tests for multi-outcome analytic variance, NN `k` handling, bootstrap-based NN exact SE, and PMM `k` choice
 
 # nonprobsvy 0.2.3

--- a/R/control_outcome.R
+++ b/R/control_outcome.R
@@ -27,15 +27,16 @@
 #' Indicate how to weight \code{k} nearest neighbours in \eqn{S_{B}} to
 #' create imputed value for units in \eqn{S_{A}}. The default value
 #' \code{"none"} indicates that mean of \code{k} nearest \eqn{y}'s from
-#' \eqn{S_{B}} should be used whereas \code{"prop_dist"} results in
+#' \eqn{S_{B}} should be used whereas \code{"dist"} results in
 #' weighted mean of these \code{k} values where weights are inversely
 #' proportional to distance between matched values.
 #' @param pmm_k_choice (Only for the PMM Estimator) Character value indicating how \code{k} hyper-parameter
 #' should be chosen, by default \code{"none"} meaning \code{k} provided in
 #' \code{control_outcome} argument will be used. For now the only other
-#' option \code{"min_var"} means that \code{k}  will be chosen by minimizing
-#' estimated variance of estimator for mean. Parameter \code{k} provided in
-#' this control list will be chosen as starting point.
+#' option \code{"min_var"} means that \code{k} will be chosen by a full
+#' search over \code{1:n_A}, where \eqn{n_A} is the non-probability sample size,
+#' minimizing the estimated variance of the mean estimator. The \code{k}
+#' value supplied in this control list is replaced by the selected value.
 #' @param pmm_reg_engine (Only for the PMM Estimator) whether to use parametric (`"glm"`)
 #' or non-parametric (`"loess"`) regression model for the outcome. The default is `"glm"`.
 #' @param npar_loess control parameters for the [stats::loess] via the [stats::loess.control] function.

--- a/R/method_nn.R
+++ b/R/method_nn.R
@@ -1,7 +1,7 @@
 #' @title Mass Imputation Using Nearest Neighbours Matching Method
 #'
 #' @importFrom stats update
-#' @importFrom survey svymean
+#' @importFrom survey svytotal
 #' @importFrom stats weighted.mean
 #' @importFrom RANN nn2
 #'
@@ -10,7 +10,9 @@
 #' The implementation is currently based on [RANN::nn2] function and thus it uses
 #' Euclidean distance for matching units from \eqn{S_A} (non-probability) to \eqn{S_B} (probability).
 #' Matching ties are randomized before donor values are aggregated, so tied nearest neighbours
-#' are not selected only by input row order. Estimation of the mean is done using \eqn{S_B} sample.
+#' are not selected only by input row order. Estimation of the mean is done using \eqn{S_B} sample:
+#' when `pop_size` is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
+#' otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
 #'
 #'
 #' @details Analytical variance
@@ -27,7 +29,9 @@
 #'
 #' where \eqn{\hat{\pi}_B(\boldsymbol{x}_i)} is an estimator of propensity scores which
 #' we currently estimate using \eqn{n_A/N} (constant) and \eqn{\hat{\sigma}^2(\boldsymbol{x}_i)} is
-#' estimated using based on the average of \eqn{(y_i - y_i^*)^2}.
+#' estimated using based on the average of \eqn{(y_i - y_i^*)^2}. The \eqn{y_i^*}
+#' values used in this proxy are obtained by leave-one-out matching in \eqn{S_A},
+#' so a unit is not used as its own donor.
 #'
 #' Chlebicki et al. (2025, Algorithm 2) proposed non-parametric mini-bootstrap estimator
 #' (without assuming that it is consistent) but with good finite population properties.
@@ -73,6 +77,9 @@
 #' @param control_inference controls passed by the `control_inf` function
 #' @param verbose parameter passed from the main `nonprob` function
 #' @param se whether standard errors should be calculated
+#' @param nn_matches optional precomputed nearest-neighbour search results for
+#'   internal reuse across outcomes. If supplied, it should be a list with
+#'   `rand` and `nons` entries from [RANN::nn2()].
 #'
 #' @returns an `nonprob_method` class which is a `list` with the following entries
 #'
@@ -126,7 +133,8 @@ method_nn <- function(y_nons,
                       control_outcome=control_out(),
                       control_inference=control_inf(),
                       verbose=FALSE,
-                      se=TRUE) {
+                      se=TRUE,
+                      nn_matches=NULL) {
 
   if (missing(y_nons) | missing(X_nons)) {
     stop("`y_nons` and `X_nons`, `X_rand` are required.")
@@ -149,7 +157,7 @@ method_nn <- function(y_nons,
       if (!any(keep)) next
       if (!any(duplicated(dists[keep]))) next
 
-      ord <- order(dists[keep], runif(sum(keep)))
+      ord <- order(dists[keep], stats::runif(sum(keep)))
       idx_mat[i, keep] <- idx[keep][ord]
       dist_mat[i, keep] <- dists[keep][ord]
     }
@@ -157,45 +165,44 @@ method_nn <- function(y_nons,
     list(idx = idx_mat, dists = dist_mat)
   }
 
-  exact_1d_matches <- function(data, query, k, exclude_self = FALSE, response = NULL) {
-    data <- as.numeric(data[, 1])
-    query <- as.numeric(query[, 1])
-    n_data <- length(data)
+  exact_matches <- function(data, query, k, exclude_self = FALSE, response = NULL) {
+    data <- as.matrix(data)
+    query <- as.matrix(query)
+    n_data <- NROW(data)
     k <- min(k, n_data - as.integer(exclude_self))
     if (k <= 0) {
       return(list(
-        idx = matrix(NA_integer_, nrow = length(query), ncol = 1),
-        dists = matrix(NA_real_, nrow = length(query), ncol = 1)
+        idx = matrix(NA_integer_, nrow = NROW(query), ncol = 1),
+        dists = matrix(NA_real_, nrow = NROW(query), ncol = 1)
       ))
     }
 
-    idx_mat <- matrix(NA_integer_, nrow = length(query), ncol = k)
-    dist_mat <- matrix(NA_real_, nrow = length(query), ncol = k)
-    unique_vals <- unique(data)
-    groups <- split(seq_along(data), match(data, unique_vals))
+    idx_mat <- matrix(NA_integer_, nrow = NROW(query), ncol = k)
+    dist_mat <- matrix(NA_real_, nrow = NROW(query), ncol = k)
+    tol <- sqrt(.Machine$double.eps)
 
-    for (i in seq_along(query)) {
-      d_unique <- abs(unique_vals - query[i])
-      dist_levels <- sort(unique(d_unique))
+    for (i in seq_len(NROW(query))) {
+      dists_all <- sqrt(rowSums(sweep(data, 2, query[i, ], FUN = "-")^2))
+      if (exclude_self && i <= length(dists_all)) dists_all[i] <- Inf
+      remaining <- which(is.finite(dists_all))
       selected <- integer()
       selected_dists <- numeric()
 
-      for (d in dist_levels) {
-        level_groups <- which(abs(d_unique - d) <= sqrt(.Machine$double.eps))
-        candidates <- unlist(groups[level_groups], use.names = FALSE)
-        if (exclude_self) candidates <- candidates[candidates != i]
-        if (!length(candidates)) next
-
-        if (length(candidates) > 1 &&
-            (is.null(response) || length(unique(response[candidates])) > 1)) {
-          candidates <- sample(candidates, length(candidates))
-        }
+      while (length(selected) < k && length(remaining)) {
+        d_min <- min(dists_all[remaining])
+        candidates <- remaining[abs(dists_all[remaining] - d_min) <= tol * max(1, d_min)]
         need <- k - length(selected)
-        take <- head(candidates, need)
+        if (length(candidates) > need &&
+            (is.null(response) || length(unique(response[candidates])) > 1)) {
+          take <- sample(candidates, need)
+        } else {
+          take <- utils::head(candidates, need)
+        }
         selected <- c(selected, take)
-        selected_dists <- c(selected_dists, rep(d, length(take)))
+        selected_dists <- c(selected_dists, dists_all[take])
 
         if (length(selected) >= k) break
+        remaining <- setdiff(remaining, candidates)
       }
 
       if (length(selected)) {
@@ -207,14 +214,9 @@ method_nn <- function(y_nons,
     list(idx = idx_mat, dists = dist_mat)
   }
 
-  use_exact_1d_matches <- function(data, query) {
-    data <- as.numeric(data[, 1])
+  use_exact_matches <- function(data, query) {
     n_query <- NROW(query)
-    n_unique <- length(unique(data))
-    exact_work <- as.numeric(n_unique) * as.numeric(n_query)
-
-    as.numeric(NROW(data)) * as.numeric(n_query) <= 2e6 ||
-      (n_unique < NROW(data) && exact_work <= 2e6)
+    as.numeric(NROW(data)) * as.numeric(n_query) <= 2e6
   }
 
   predict_from_matches <- function(nn_fit,
@@ -224,10 +226,10 @@ method_nn <- function(y_nons,
                                    data = NULL,
                                    query = NULL,
                                    k = NULL) {
-    if (!is.null(data) && !is.null(query) && NCOL(data) == 1 && !is.null(k) &&
-        use_exact_1d_matches(data, query)) {
-      matches <- exact_1d_matches(data = data, query = query, k = k,
-                                  exclude_self = exclude_self, response = response)
+    if (!is.null(data) && !is.null(query) && !is.null(k) &&
+        use_exact_matches(data, query)) {
+      matches <- exact_matches(data = data, query = query, k = k,
+                               exclude_self = exclude_self, response = response)
       idx_mat <- matches$idx
       dist_mat <- matches$dists
       exclude_self <- FALSE
@@ -273,21 +275,29 @@ method_nn <- function(y_nons,
     message("Matching units between samples...")
   }
 
-  model_fitted_nons <- RANN::nn2(
-    data = X_nons,
-    query = X_nons,
-    k = min(control_outcome$k + 1L, NROW(X_nons)),
-    treetype = control_outcome$treetype,
-    searchtype = control_outcome$searchtype
-  )
+  model_fitted_nons <- if (!is.null(nn_matches$nons)) {
+    nn_matches$nons
+  } else {
+    RANN::nn2(
+      data = X_nons,
+      query = X_nons,
+      k = min(control_outcome$k + 1L, NROW(X_nons)),
+      treetype = control_outcome$treetype,
+      searchtype = control_outcome$searchtype
+    )
+  }
 
-  model_fitted <- RANN::nn2(
-    data = X_nons,
-    query = X_rand,
-    k = control_outcome$k,
-    treetype = control_outcome$treetype,
-    searchtype = control_outcome$searchtype
-  )
+  model_fitted <- if (!is.null(nn_matches$rand)) {
+    nn_matches$rand
+  } else {
+    RANN::nn2(
+      data = X_nons,
+      query = X_rand,
+      k = control_outcome$k,
+      treetype = control_outcome$treetype,
+      searchtype = control_outcome$searchtype
+    )
+  }
 
   y_rand_pred <- switch(control_outcome$pmm_weights, ## this should be changed to nn_weights
                         "none" = predict_from_matches(model_fitted, y_nons,
@@ -299,13 +309,13 @@ method_nn <- function(y_nons,
   )
 
   svydesign_updated <- stats::update(svydesign, y_hat_MI = y_rand_pred)
-  svydesign_mean <- survey::svymean( ~ y_hat_MI, svydesign_updated)
-  y_mi_hat <- as.numeric(svydesign_mean)
+  svydesign_total <- survey::svytotal( ~ y_hat_MI, svydesign_updated)
+  y_mi_hat <- as.numeric(svydesign_total) / pop_size
   y_nons_pred <- NULL
 
   if (se) {
 
-    var_prob <- as.vector(attr(svydesign_mean, "var"))
+    var_prob <- as.vector(attr(svydesign_total, "var")) / pop_size^2
     var_nonprob <- 0
     var_total <- var_prob
 
@@ -347,7 +357,7 @@ method_nn <- function(y_nons,
                                                                       data = X_nons_b, query = X_rand,
                                                                       k = control_outcome$k))
 
-        dd[jj] <- stats::weighted.mean(y_rand_pred_mini_boot, weights(svydesign))
+        dd[jj] <- sum(weights(svydesign) * y_rand_pred_mini_boot) / pop_size
       }
       var_nonprob <- var(dd)
       var_total <- var_prob + var_nonprob

--- a/R/method_nn.R
+++ b/R/method_nn.R
@@ -13,6 +13,9 @@
 #' are not selected only by input row order. Estimation of the mean is done using \eqn{S_B} sample:
 #' when `pop_size` is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
 #' otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
+#' The `pop_size` argument is not converted into a finite population correction;
+#' if an fpc is needed, it should be supplied in `svydesign`, where it is handled
+#' by the `{survey}` variance routines.
 #'
 #'
 #' @details Analytical variance
@@ -72,7 +75,10 @@
 #' @param start_outcome a placeholder (not used in `method_nn`)
 #' @param vars_selection whether variable selection should be conducted
 #' @param pop_totals a placeholder (not used in `method_nn`)
-#' @param pop_size population size from the `nonprob` function
+#' @param pop_size population size from the `nonprob` function. If `NULL`, the
+#'   method uses `sum(weights(svydesign))`. If supplied, it is used as the
+#'   known-\eqn{N} denominator for the mean and variance scaling, but it does not
+#'   modify the finite population correction of `svydesign`.
 #' @param control_outcome controls passed by the `control_out` function
 #' @param control_inference controls passed by the `control_inf` function
 #' @param verbose parameter passed from the main `nonprob` function
@@ -309,6 +315,7 @@ method_nn <- function(y_nons,
   )
 
   svydesign_updated <- stats::update(svydesign, y_hat_MI = y_rand_pred)
+  # svytotal() honors any fpc already stored in svydesign; pop_size is only the mean denominator.
   svydesign_total <- survey::svytotal( ~ y_hat_MI, svydesign_updated)
   y_mi_hat <- as.numeric(svydesign_total) / pop_size
   y_nons_pred <- NULL

--- a/R/method_pmm.R
+++ b/R/method_pmm.R
@@ -2,7 +2,9 @@
 #'
 #' @description
 #' Model for the outcome for the mass imputation estimator. The implementation is currently based on [RANN::nn2] function and thus it uses Euclidean distance for matching units from \eqn{S_A} (non-probability) to \eqn{S_B} (probability) based on predicted values from model \eqn{\boldsymbol{x}_i} based
-#' either on `method_glm` or `method_npar`. Estimation of the mean is done using \eqn{S_B} sample.
+#' either on `method_glm` or `method_npar`. Estimation of the mean is done using \eqn{S_B} sample:
+#' when `pop_size` is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
+#' otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
 #' Matching ties are randomized by the nearest-neighbour step before donor values are aggregated.
 #'
 #' This implementation extends Yang et al. (2021) approach as described in Chlebicki et al. (2025), namely:
@@ -14,8 +16,8 @@
 #'  approach to estimate variance from the non-probability sample  (`nn_exact_se` from the [control_inf()] function).
 #'  If non-constant pseudo-weights are supplied, bootstrap samples are drawn with probabilities
 #'  proportional to inverse weights and the resampled weights are used in each refitted outcome model.}
-#'  \item{pmm_k_choice}{the main `nonprob` function allows for dynamic selection of `k` neighbours based on the
-#'  variance minimization procedure (`pmm_k_choice` from the [control_out()] function)}
+#'  \item{pmm_k_choice}{the main `nonprob` function allows for dynamic selection of `k` neighbours based on a
+#'  full-grid variance minimization procedure over \code{1:n_A} (`pmm_k_choice` from the [control_out()] function)}
 #' }
 #'
 #' @details
@@ -121,6 +123,7 @@ method_pmm <- function(y_nons,
                        se=TRUE) {
 
   if (is.null(weights)) weights <- rep(1, NROW(X_nons))
+  if (is.null(pop_size)) pop_size <- sum(weights(svydesign))
   boot_prob <- if (length(unique(weights)) == 1) NULL else 1 / weights
 
   ## passing arguments to the specified method of estimation E(Y|X)
@@ -184,8 +187,8 @@ method_pmm <- function(y_nons,
 
 
   if (se) {
-    svydesign_mean <- svymean(~y_hat_MI, pmm_results$svydesign)
-    var_prob <- as.vector(attr(svydesign_mean, "var"))
+    svydesign_total <- survey::svytotal(~y_hat_MI, pmm_results$svydesign)
+    var_prob <- as.vector(attr(svydesign_total, "var")) / pop_size^2
     var_nonprob <- 0
 
     if (control_inference$nn_exact_se) {

--- a/R/method_pmm.R
+++ b/R/method_pmm.R
@@ -5,6 +5,9 @@
 #' either on `method_glm` or `method_npar`. Estimation of the mean is done using \eqn{S_B} sample:
 #' when `pop_size` is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
 #' otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
+#' The `pop_size` argument is not converted into a finite population correction;
+#' if an fpc is needed, it should be supplied in `svydesign`, where it is handled
+#' by the `{survey}` variance routines.
 #' Matching ties are randomized by the nearest-neighbour step before donor values are aggregated.
 #'
 #' This implementation extends Yang et al. (2021) approach as described in Chlebicki et al. (2025), namely:
@@ -71,7 +74,10 @@
 #' @param start_outcome start parameters
 #' @param vars_selection whether variable selection should be conducted
 #' @param pop_totals a place holder (not used in `method_pmm`)
-#' @param pop_size population size from the `nonprob` function
+#' @param pop_size population size from the `nonprob` function. If `NULL`, the
+#'   method uses `sum(weights(svydesign))`. If supplied, it is used as the
+#'   known-\eqn{N} denominator for the mean and variance scaling, but it does not
+#'   modify the finite population correction of `svydesign`.
 #' @param control_outcome controls passed by the `control_out` function
 #' @param control_inference controls passed by the `control_inf` function
 #' @param verbose parameter passed from the main `nonprob` function
@@ -187,6 +193,7 @@ method_pmm <- function(y_nons,
 
 
   if (se) {
+    # svytotal() honors any fpc already stored in svydesign; pop_size is only the mean denominator.
     svydesign_total <- survey::svytotal(~y_hat_MI, pmm_results$svydesign)
     var_prob <- as.vector(attr(svydesign_total, "var")) / pop_size^2
     var_nonprob <- 0

--- a/R/nonprob_documentation.R
+++ b/R/nonprob_documentation.R
@@ -18,10 +18,13 @@
 #' @param selection a `formula` (default `NULL`) for the selection (propensity) score model
 #' @param outcome a `formula` (default `NULL`) for the outcome (target) model
 #' @param target a `formula` (default `NULL`) with target variable(s). We allow multiple target variables (e.g. `~y1 + y2 + y3`)
-#' @param svydesign an optional `svydesign2` class object containing a probability sample and design weights
+#' @param svydesign an optional `svydesign2` class object containing a probability sample and design weights.
+#' If finite population correction should affect survey-side variance estimates, include the fpc in this object.
 #' @param pop_totals an optional `named vector` with population totals of the covariates
 #' @param pop_means an optional `named vector` with population means of the covariates
-#' @param pop_size an optional `double` value with population size
+#' @param pop_size an optional `double` value with population size. If omitted when a probability sample is supplied,
+#' `pop_size` is estimated as `sum(weights(svydesign))`. Supplying `pop_size` fixes the population-size denominator
+#' used by known-\eqn{N} estimators; it does not add or modify finite population correction in `svydesign`.
 #' @param method_selection a `character` (default `logit`) indicating the method for the propensity score link function.
 #' @param method_outcome a `character` (default `glm`) indicating the method for the outcome model.
 #' @param family_outcome a `character` (default `gaussian`)  describing the error distribution and the link function to be used in the model. Currently supports: `gaussian` with the identity link, `poisson` and `binomial`.

--- a/R/nonprob_mi.R
+++ b/R/nonprob_mi.R
@@ -46,6 +46,7 @@ nonprob_mi <- function(outcome,
 
   ys_resid <- ys_rand_pred <- ys_nons_pred <- ys <- list()
   outcome_list <- list()
+  nn_match_cache <- NULL
 
   if (se) {
     confidence_interval <- list()
@@ -59,7 +60,7 @@ nonprob_mi <- function(outcome,
 
     outcome_model_data <- make_model_frame(formula = outcomes$outcome[[o]],
                                            data = data,
-                                           weights = weights,
+                                           weights = case_weights,
                                            svydesign = svydesign,
                                            pop_totals = pop_totals)
 
@@ -68,18 +69,50 @@ nonprob_mi <- function(outcome,
     nons_names <- outcome_model_data$nons_names
     y_nons <- outcome_model_data$y_nons
     pop_totals_ <- outcome_model_data$pop_totals ## match the same as in X_nons
+    nn_matches <- NULL
+
+    if (method_outcome == "nn" && !is.null(svydesign)) {
+      cache_matches <- !is.null(nn_match_cache) &&
+        identical(nn_match_cache$X_nons, X_nons) &&
+        identical(nn_match_cache$X_rand, X_rand) &&
+        identical(nn_match_cache$k, control_outcome$k) &&
+        identical(nn_match_cache$treetype, control_outcome$treetype) &&
+        identical(nn_match_cache$searchtype, control_outcome$searchtype)
+
+      if (!cache_matches) {
+        nn_match_cache <- list(
+          X_nons = X_nons,
+          X_rand = X_rand,
+          k = control_outcome$k,
+          treetype = control_outcome$treetype,
+          searchtype = control_outcome$searchtype,
+          matches = list(
+            nons = RANN::nn2(
+              data = X_nons,
+              query = X_nons,
+              k = min(control_outcome$k + 1L, NROW(X_nons)),
+              treetype = control_outcome$treetype,
+              searchtype = control_outcome$searchtype
+            ),
+            rand = RANN::nn2(
+              data = X_nons,
+              query = X_rand,
+              k = control_outcome$k,
+              treetype = control_outcome$treetype,
+              searchtype = control_outcome$searchtype
+            )
+          )
+        )
+      }
+
+      nn_matches <- nn_match_cache$matches
+    }
 
     if (control_outcome$pmm_k_choice == "min_var" & method_outcome == "pmm") {
-      # This can be programmed a lot better possibly with custom method outcome that would
-      # store previous k-pmm model and omit the last estimation
-      ## TODO:: right now this only goes forward not backwards
       best_var <- Inf
       best_k <- 1L
       best_model_obj <- NULL
-      cond <- TRUE
-      kk <- 0
-      while (cond && kk < NROW(X_nons)) {
-        kk <- kk + 1
+      for (kk in seq_len(NROW(X_nons))) {
         control_outcome$k <- kk
         candidate_model <- outcome_method(y_nons = y_nons,
                                           X_nons = X_nons,
@@ -99,13 +132,15 @@ nonprob_mi <- function(outcome,
         # variance
         var_now <- candidate_model$var_total
 
-        if (var_now < best_var) {
+        if (!is.na(var_now) && var_now < best_var) {
           best_var <- var_now
           best_k <- kk
           best_model_obj <- candidate_model
-        } else {
-          cond <- FALSE
         }
+      }
+
+      if (is.null(best_model_obj)) {
+        stop("Unable to select `k`: all PMM candidate variances are missing.")
       }
 
       if (isTRUE(verbose)) {
@@ -132,20 +167,24 @@ nonprob_mi <- function(outcome,
                        se=se)
       }
     } else {
-      model_obj <- outcome_method(y_nons = y_nons,
-                                  X_nons = X_nons,
-                                  X_rand = X_rand,
-                                  svydesign = svydesign,
-                                  weights=case_weights,
-                                  family_outcome=family_outcome,
-                                  start_outcome=start_outcome,
-                                  vars_selection=vars_selection,
-                                  pop_totals=pop_totals_,
-                                  pop_size=pop_size,
-                                  control_outcome=control_outcome,
-                                  control_inference=control_inference,
-                                  verbose=verbose,
-                                  se=se)
+      model_args <- list(y_nons = y_nons,
+                         X_nons = X_nons,
+                         X_rand = X_rand,
+                         svydesign = svydesign,
+                         weights=case_weights,
+                         family_outcome=family_outcome,
+                         start_outcome=start_outcome,
+                         vars_selection=vars_selection,
+                         pop_totals=pop_totals_,
+                         pop_size=pop_size,
+                         control_outcome=control_outcome,
+                         control_inference=control_inference,
+                         verbose=verbose,
+                         se=se)
+      if (method_outcome == "nn" && !is.null(nn_matches)) {
+        model_args$nn_matches <- nn_matches
+      }
+      model_obj <- do.call(outcome_method, model_args)
     }
 
 
@@ -197,20 +236,24 @@ nonprob_mi <- function(outcome,
 
         if (isTRUE(control_inference$nn_exact_se) & method_outcome %in% c("pmm", "nn")) {
           ## mini-bootstrap as suggested in the MI-PMM paper
-          boot_obj_comp2 <- outcome_method(y_nons = y_nons,
-                                           X_nons = X_nons,
-                                           X_rand = X_rand,
-                                           svydesign = svydesign,
-                                           weights=case_weights,
-                                           family_outcome=family_outcome,
-                                           start_outcome=start_outcome,
-                                           vars_selection=vars_selection,
-                                           pop_totals=pop_totals_,
-                                           pop_size=pop_size,
-                                           control_outcome=control_outcome,
-                                           control_inference=control_inference,
-                                           verbose=verbose,
-                                           se=se)
+          comp2_args <- list(y_nons = y_nons,
+                             X_nons = X_nons,
+                             X_rand = X_rand,
+                             svydesign = svydesign,
+                             weights=case_weights,
+                             family_outcome=family_outcome,
+                             start_outcome=start_outcome,
+                             vars_selection=vars_selection,
+                             pop_totals=pop_totals_,
+                             pop_size=pop_size,
+                             control_outcome=control_outcome,
+                             control_inference=control_inference,
+                             verbose=verbose,
+                             se=se)
+          if (method_outcome == "nn" && !is.null(nn_matches)) {
+            comp2_args$nn_matches <- nn_matches
+          }
+          boot_obj_comp2 <- do.call(outcome_method, comp2_args)
 
           comp2 <- boot_obj_comp2$var_nonprob
         } else {

--- a/inst/tinytest/test_nn_k.R
+++ b/inst/tinytest/test_nn_k.R
@@ -29,6 +29,18 @@ expect_equal(
   c(1, 9)
 )
 
+expect_equal(
+  fit_nn_k1$y_mi_hat,
+  (2 * 1 + 3 * 9) / 10,
+  tolerance = 1e-12
+)
+
+expect_equal(
+  fit_nn_k1$var_prob,
+  as.vector(attr(survey::svytotal(~y_hat_MI, fit_nn_k1$svydesign), "var")) / 10^2,
+  tolerance = 1e-12
+)
+
 fit_nn_k1_dist <- method_nn(
   y_nons = c(1, 4, 9),
   X_nons = matrix(c(0, 2, 5), ncol = 1),
@@ -54,7 +66,7 @@ fit_nonprob_nn_k1 <- nonprob(
 
 expect_equal(
   fit_nonprob_nn_k1$output,
-  data.frame(mean = 0.646597258018859, SE = 0.0279237332302402,
+  data.frame(mean = 0.646597262386736, SE = 0.037762604895233,
              row.names = "single_shift"),
   tolerance = 1e-6
 )
@@ -82,7 +94,7 @@ for (jj in 1:50) {
   X_nons_b <- matrix(c(0, 5, 10)[boot_samp], ncol = 1)
   boot_matches <- RANN::nn2(data = X_nons_b, query = matrix(c(9, 8), ncol = 1), k = 1)
   y_pred_boot <- y_nons_b[boot_matches$nn.idx[, 1]]
-  dd_manual[jj] <- stats::weighted.mean(y_pred_boot, c(2, 3))
+  dd_manual[jj] <- sum(c(2, 3) * y_pred_boot) / 10
 }
 
 expect_equal(
@@ -114,7 +126,7 @@ for (jj in 1:50) {
   X_nons_b <- matrix(c(0, 5, 10)[boot_samp], ncol = 1)
   boot_matches <- RANN::nn2(data = X_nons_b, query = matrix(c(9, 8), ncol = 1), k = 1)
   y_pred_boot <- y_nons_b[boot_matches$nn.idx[, 1]]
-  dd_manual_weighted[jj] <- stats::weighted.mean(y_pred_boot, c(2, 3))
+  dd_manual_weighted[jj] <- sum(c(2, 3) * y_pred_boot) / 10
 }
 
 expect_equal(
@@ -136,3 +148,37 @@ tie_predictions <- replicate(40, method_nn(
 )$y_rand_pred)
 
 expect_equal(sort(unique(as.numeric(tie_predictions))), c(1, 3))
+
+local({
+  assign(".nonprobsvy_test_nn2_calls", 0L, envir = .GlobalEnv)
+  trace(
+    "nn2",
+    where = asNamespace("RANN"),
+    tracer = quote(assign(
+      ".nonprobsvy_test_nn2_calls",
+      get(".nonprobsvy_test_nn2_calls", envir = .GlobalEnv) + 1L,
+      envir = .GlobalEnv
+    )),
+    print = FALSE
+  )
+  on.exit({
+    untrace("nn2", where = asNamespace("RANN"))
+    rm(".nonprobsvy_test_nn2_calls", envir = .GlobalEnv)
+  }, add = TRUE)
+
+  multi_outcome_nn <- nonprob(
+    outcome = y1 + y2 ~ x,
+    data = data.frame(x = c(0, 2, 5), y1 = c(1, 4, 9), y2 = c(3, 6, 12)),
+    svydesign = toy_svy,
+    method_outcome = "nn",
+    control_outcome = control_out(k = 1),
+    se = FALSE
+  )
+
+  expect_equal(get(".nonprobsvy_test_nn2_calls", envir = .GlobalEnv), 2L)
+  expect_equal(
+    unname(multi_outcome_nn$output$mean),
+    c(5.8, 8.4),
+    tolerance = 1e-12
+  )
+})

--- a/inst/tinytest/test_pmm_k_choice.R
+++ b/inst/tinytest/test_pmm_k_choice.R
@@ -1,19 +1,26 @@
 source("_code_for_all_.R")
 
+min_var_nonprob <- data.frame(
+  x = c(-1.8177740, -0.3640923, 0.1124220, 1.5320696, 1.5696762, 1.7618691),
+  y = c(0.1292877, 1.7150650, 0.4609162, -1.2650612, -3.6868529, -3.4456620)
+)
+min_var_prob <- data.frame(
+  x = c(-1.90154526, -0.08881612, 0.76282111, 1.18186967),
+  w = c(3.275379, 1.649224, 1.954543, 1.694877)
+)
+min_var_svy <- svydesign(ids = ~1, weights = ~w, data = min_var_prob)
+
 fit_pmm_min_var <- nonprob(
-  outcome = single_shift ~ region + private + nace + size,
-  svydesign = jvs_svy,
+  outcome = y ~ x,
+  svydesign = min_var_svy,
   method_outcome = "pmm",
-  data = admin,
+  data = min_var_nonprob,
   control_outcome = control_out(pmm_k_choice = "min_var", pmm_reg_engine = "glm")
 )
 
-expect_true(
-  fit_pmm_min_var$control$control_outcome$k >= 1
-)
-
-expect_true(
-  fit_pmm_min_var$control$control_outcome$k <= nrow(admin)
+expect_equal(
+  fit_pmm_min_var$control$control_outcome$k,
+  5L
 )
 
 expect_true(
@@ -39,6 +46,13 @@ fit_pmm_weighted_boot <- method_pmm(
   control_outcome = control_out(k = 1, pmm_reg_engine = "glm"),
   control_inference = control_inf(nn_exact_se = TRUE),
   se = TRUE
+)
+
+expect_equal(
+  fit_pmm_weighted_boot$y_mi_hat,
+  sum(weights(fit_pmm_weighted_boot$svydesign) *
+        fit_pmm_weighted_boot$svydesign$variables$y_hat_MI) / 10,
+  tolerance = 1e-12
 )
 
 set.seed(27)

--- a/man/control_out.Rd
+++ b/man/control_out.Rd
@@ -61,16 +61,17 @@ is matching by minimizing distance between \eqn{\hat{y}_{i}} for
 Indicate how to weight \code{k} nearest neighbours in \eqn{S_{B}} to
 create imputed value for units in \eqn{S_{A}}. The default value
 \code{"none"} indicates that mean of \code{k} nearest \eqn{y}'s from
-\eqn{S_{B}} should be used whereas \code{"prop_dist"} results in
+\eqn{S_{B}} should be used whereas \code{"dist"} results in
 weighted mean of these \code{k} values where weights are inversely
 proportional to distance between matched values.}
 
 \item{pmm_k_choice}{(Only for the PMM Estimator) Character value indicating how \code{k} hyper-parameter
 should be chosen, by default \code{"none"} meaning \code{k} provided in
 \code{control_outcome} argument will be used. For now the only other
-option \code{"min_var"} means that \code{k}  will be chosen by minimizing
-estimated variance of estimator for mean. Parameter \code{k} provided in
-this control list will be chosen as starting point.}
+option \code{"min_var"} means that \code{k} will be chosen by a full
+search over \code{1:n_A}, where \eqn{n_A} is the non-probability sample size,
+minimizing the estimated variance of the mean estimator. The \code{k}
+value supplied in this control list is replaced by the selected value.}
 
 \item{pmm_reg_engine}{(Only for the PMM Estimator) whether to use parametric (\code{"glm"})
 or non-parametric (\code{"loess"}) regression model for the outcome. The default is \code{"glm"}.}

--- a/man/method_nn.Rd
+++ b/man/method_nn.Rd
@@ -18,7 +18,8 @@ method_nn(
   control_outcome = control_out(),
   control_inference = control_inf(),
   verbose = FALSE,
-  se = TRUE
+  se = TRUE,
+  nn_matches = NULL
 )
 }
 \arguments{
@@ -51,6 +52,10 @@ to their inverses.}
 \item{verbose}{parameter passed from the main \code{nonprob} function}
 
 \item{se}{whether standard errors should be calculated}
+
+\item{nn_matches}{optional precomputed nearest-neighbour search results for
+internal reuse across outcomes. If supplied, it should be a list with
+\code{rand} and \code{nons} entries from \code{\link[RANN:nn2]{RANN::nn2()}}.}
 }
 \value{
 an \code{nonprob_method} class which is a \code{list} with the following entries
@@ -75,7 +80,9 @@ Mass imputation using nearest neighbours approach as described in Yang et al. (2
 The implementation is currently based on \link[RANN:nn2]{RANN::nn2} function and thus it uses
 Euclidean distance for matching units from \eqn{S_A} (non-probability) to \eqn{S_B} (probability).
 Matching ties are randomized before donor values are aggregated, so tied nearest neighbours
-are not selected only by input row order. Estimation of the mean is done using \eqn{S_B} sample.
+are not selected only by input row order. Estimation of the mean is done using \eqn{S_B} sample:
+when \code{pop_size} is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
+otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
 }
 \details{
 Analytical variance
@@ -92,7 +99,9 @@ This may be estimated using
 
 where \eqn{\hat{\pi}_B(\boldsymbol{x}_i)} is an estimator of propensity scores which
 we currently estimate using \eqn{n_A/N} (constant) and \eqn{\hat{\sigma}^2(\boldsymbol{x}_i)} is
-estimated using based on the average of \eqn{(y_i - y_i^*)^2}.
+estimated using based on the average of \eqn{(y_i - y_i^*)^2}. The \eqn{y_i^*}
+values used in this proxy are obtained by leave-one-out matching in \eqn{S_A},
+so a unit is not used as its own donor.
 
 Chlebicki et al. (2025, Algorithm 2) proposed non-parametric mini-bootstrap estimator
 (without assuming that it is consistent) but with good finite population properties.

--- a/man/method_nn.Rd
+++ b/man/method_nn.Rd
@@ -43,7 +43,10 @@ to their inverses.}
 
 \item{pop_totals}{a placeholder (not used in \code{method_nn})}
 
-\item{pop_size}{population size from the \code{nonprob} function}
+\item{pop_size}{population size from the \code{nonprob} function. If \code{NULL}, the
+method uses \code{sum(weights(svydesign))}. If supplied, it is used as the
+known-\eqn{N} denominator for the mean and variance scaling, but it does not
+modify the finite population correction of \code{svydesign}.}
 
 \item{control_outcome}{controls passed by the \code{control_out} function}
 
@@ -83,6 +86,9 @@ Matching ties are randomized before donor values are aggregated, so tied nearest
 are not selected only by input row order. Estimation of the mean is done using \eqn{S_B} sample:
 when \code{pop_size} is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
 otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
+The \code{pop_size} argument is not converted into a finite population correction;
+if an fpc is needed, it should be supplied in \code{svydesign}, where it is handled
+by the \code{{survey}} variance routines.
 }
 \details{
 Analytical variance

--- a/man/method_pmm.Rd
+++ b/man/method_pmm.Rd
@@ -42,7 +42,10 @@ to their inverses and are resampled for each bootstrap refit.}
 
 \item{pop_totals}{a place holder (not used in \code{method_pmm})}
 
-\item{pop_size}{population size from the \code{nonprob} function}
+\item{pop_size}{population size from the \code{nonprob} function. If \code{NULL}, the
+method uses \code{sum(weights(svydesign))}. If supplied, it is used as the
+known-\eqn{N} denominator for the mean and variance scaling, but it does not
+modify the finite population correction of \code{svydesign}.}
 
 \item{control_outcome}{controls passed by the \code{control_out} function}
 
@@ -74,6 +77,9 @@ Model for the outcome for the mass imputation estimator. The implementation is c
 either on \code{method_glm} or \code{method_npar}. Estimation of the mean is done using \eqn{S_B} sample:
 when \code{pop_size} is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
 otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
+The \code{pop_size} argument is not converted into a finite population correction;
+if an fpc is needed, it should be supplied in \code{svydesign}, where it is handled
+by the \code{{survey}} variance routines.
 Matching ties are randomized by the nearest-neighbour step before donor values are aggregated.
 
 This implementation extends Yang et al. (2021) approach as described in Chlebicki et al. (2025), namely:

--- a/man/method_pmm.Rd
+++ b/man/method_pmm.Rd
@@ -71,7 +71,9 @@ an \code{nonprob_method} class which is a \code{list} with the following entries
 }
 \description{
 Model for the outcome for the mass imputation estimator. The implementation is currently based on \link[RANN:nn2]{RANN::nn2} function and thus it uses Euclidean distance for matching units from \eqn{S_A} (non-probability) to \eqn{S_B} (probability) based on predicted values from model \eqn{\boldsymbol{x}_i} based
-either on \code{method_glm} or \code{method_npar}. Estimation of the mean is done using \eqn{S_B} sample.
+either on \code{method_glm} or \code{method_npar}. Estimation of the mean is done using \eqn{S_B} sample:
+when \code{pop_size} is supplied this is the known-\eqn{N} Horvitz-Thompson mean,
+otherwise it reduces to the usual ratio mean with \eqn{\hat{N} = \sum_{i\in S_B} d_i}.
 Matching ties are randomized by the nearest-neighbour step before donor values are aggregated.
 
 This implementation extends Yang et al. (2021) approach as described in Chlebicki et al. (2025), namely:
@@ -83,8 +85,8 @@ matrix returned by \link[RANN:nn2]{RANN::nn2} function (\code{pmm_weights} from 
 approach to estimate variance from the non-probability sample  (\code{nn_exact_se} from the \code{\link[=control_inf]{control_inf()}} function).
 If non-constant pseudo-weights are supplied, bootstrap samples are drawn with probabilities
 proportional to inverse weights and the resampled weights are used in each refitted outcome model.}
-\item{pmm_k_choice}{the main \code{nonprob} function allows for dynamic selection of \code{k} neighbours based on the
-variance minimization procedure (\code{pmm_k_choice} from the \code{\link[=control_out]{control_out()}} function)}
+\item{pmm_k_choice}{the main \code{nonprob} function allows for dynamic selection of \code{k} neighbours based on a
+full-grid variance minimization procedure over \code{1:n_A} (\code{pmm_k_choice} from the \code{\link[=control_out]{control_out()}} function)}
 }
 }
 \details{

--- a/man/nonprob.Rd
+++ b/man/nonprob.Rd
@@ -39,13 +39,16 @@ nonprob(
 
 \item{target}{a \code{formula} (default \code{NULL}) with target variable(s). We allow multiple target variables (e.g. \code{~y1 + y2 + y3})}
 
-\item{svydesign}{an optional \code{svydesign2} class object containing a probability sample and design weights}
+\item{svydesign}{an optional \code{svydesign2} class object containing a probability sample and design weights.
+If finite population correction should affect survey-side variance estimates, include the fpc in this object.}
 
 \item{pop_totals}{an optional \verb{named vector} with population totals of the covariates}
 
 \item{pop_means}{an optional \verb{named vector} with population means of the covariates}
 
-\item{pop_size}{an optional \code{double} value with population size}
+\item{pop_size}{an optional \code{double} value with population size. If omitted when a probability sample is supplied,
+\code{pop_size} is estimated as \code{sum(weights(svydesign))}. Supplying \code{pop_size} fixes the population-size denominator
+used by known-\eqn{N} estimators; it does not add or modify finite population correction in \code{svydesign}.}
 
 \item{method_selection}{a \code{character} (default \code{logit}) indicating the method for the propensity score link function.}
 


### PR DESCRIPTION
Fixes #99. Fixes #104. Fixes #105. Fixes #106. Fixes #107. Fixes #108.\n\nSummary:\n- aligns NN/PMM known-N point estimates and probability variance with HT total-over-N scaling\n- switches PMM min_var k selection to a full 1:n_A grid search\n- reuses NN search results across multi-outcome NN fits\n- tightens random tie handling and fixes model-frame case_weights plumbing\n- updates roxygen/Rd docs and NEWS\n\nValidation:\n- tinytest::run_test_dir('inst/tinytest'): PASS, 175 results\n- R CMD check --no-manual --no-build-vignettes: 1 WARNING from local dependency R-version mismatch only