### PR TITLE
Reuse NN search across outcomes

### DIFF
--- a/R/method_nn.R
+++ b/R/method_nn.R
@@ -68,6 +68,9 @@
 #' @param control_inference controls passed by the `control_inf` function
 #' @param verbose parameter passed from the main `nonprob` function
 #' @param se whether standard errors should be calculated
+#' @param nn_matches optional precomputed nearest-neighbour search results for
+#'   internal reuse across outcomes. If supplied, it should be a list with
+#'   `rand` and `nons` entries from [RANN::nn2()].
 #'
 #' @returns an `nonprob_method` class which is a `list` with the following entries
 #'
@@ -121,7 +124,8 @@ method_nn <- function(y_nons,
                       control_outcome=control_out(),
                       control_inference=control_inf(),
                       verbose=FALSE,
-                      se=TRUE) {
+                      se=TRUE,
+                      nn_matches=NULL) {
 
   if (missing(y_nons) | missing(X_nons)) {
     stop("`y_nons` and `X_nons`, `X_rand` are required.")
@@ -137,21 +141,29 @@ method_nn <- function(y_nons,
     message("Matching units between samples...")
   }
 
-  model_fitted_nons <- RANN::nn2(
-    data = X_nons,
-    query = X_nons,
-    k = control_outcome$k,
-    treetype = control_outcome$treetype,
-    searchtype = control_outcome$searchtype
-  )
+  model_fitted_nons <- if (!is.null(nn_matches) && !is.null(nn_matches$nons)) {
+    nn_matches$nons
+  } else {
+    RANN::nn2(
+      data = X_nons,
+      query = X_nons,
+      k = control_outcome$k,
+      treetype = control_outcome$treetype,
+      searchtype = control_outcome$searchtype
+    )
+  }
 
-  model_fitted <- RANN::nn2(
-    data = X_nons,
-    query = X_rand,
-    k = control_outcome$k,
-    treetype = control_outcome$treetype,
-    searchtype = control_outcome$searchtype
-  )
+  model_fitted <- if (!is.null(nn_matches) && !is.null(nn_matches$rand)) {
+    nn_matches$rand
+  } else {
+    RANN::nn2(
+      data = X_nons,
+      query = X_rand,
+      k = control_outcome$k,
+      treetype = control_outcome$treetype,
+      searchtype = control_outcome$searchtype
+    )
+  }
 
   k_range <- 1:control_outcome$k
 

--- a/R/nonprob_mi.R
+++ b/R/nonprob_mi.R
@@ -46,6 +46,7 @@ nonprob_mi <- function(outcome,
 
   ys_resid <- ys_rand_pred <- ys_nons_pred <- ys <- list()
   outcome_list <- list()
+  nn_match_cache <- NULL
 
   if (se) {
     confidence_interval <- list()
@@ -68,21 +69,64 @@ nonprob_mi <- function(outcome,
     nons_names <- outcome_model_data$nons_names
     y_nons <- outcome_model_data$y_nons
     pop_totals_ <- outcome_model_data$pop_totals ## match the same as in X_nons
+    nn_matches <- NULL
 
-    model_obj <- outcome_method(y_nons = y_nons,
-                                X_nons = X_nons,
-                                X_rand = X_rand,
-                                svydesign = svydesign,
-                                weights=case_weights,
-                                family_outcome=family_outcome,
-                                start_outcome=start_outcome,
-                                vars_selection=vars_selection,
-                                pop_totals=pop_totals_,
-                                pop_size=pop_size,
-                                control_outcome=control_outcome,
-                                control_inference=control_inference,
-                                verbose=verbose,
-                                se=se)
+    if (method_outcome == "nn" && !is.null(svydesign)) {
+      cache_matches <- !is.null(nn_match_cache) &&
+        identical(nn_match_cache$X_nons, X_nons) &&
+        identical(nn_match_cache$X_rand, X_rand) &&
+        identical(nn_match_cache$k, control_outcome$k) &&
+        identical(nn_match_cache$treetype, control_outcome$treetype) &&
+        identical(nn_match_cache$searchtype, control_outcome$searchtype)
+
+      if (!cache_matches) {
+        nn_match_cache <- list(
+          X_nons = X_nons,
+          X_rand = X_rand,
+          k = control_outcome$k,
+          treetype = control_outcome$treetype,
+          searchtype = control_outcome$searchtype,
+          matches = list(
+            nons = RANN::nn2(
+              data = X_nons,
+              query = X_nons,
+              k = control_outcome$k,
+              treetype = control_outcome$treetype,
+              searchtype = control_outcome$searchtype
+            ),
+            rand = RANN::nn2(
+              data = X_nons,
+              query = X_rand,
+              k = control_outcome$k,
+              treetype = control_outcome$treetype,
+              searchtype = control_outcome$searchtype
+            )
+          )
+        )
+      }
+
+      nn_matches <- nn_match_cache$matches
+    }
+
+    model_args <- list(y_nons = y_nons,
+                       X_nons = X_nons,
+                       X_rand = X_rand,
+                       svydesign = svydesign,
+                       weights=case_weights,
+                       family_outcome=family_outcome,
+                       start_outcome=start_outcome,
+                       vars_selection=vars_selection,
+                       pop_totals=pop_totals_,
+                       pop_size=pop_size,
+                       control_outcome=control_outcome,
+                       control_inference=control_inference,
+                       verbose=verbose,
+                       se=se)
+    if (method_outcome == "nn" && !is.null(nn_matches)) {
+      model_args$nn_matches <- nn_matches
+    }
+
+    model_obj <- do.call(outcome_method, model_args)
 
     if (control_outcome$pmm_k_choice == "min_var" & method_outcome == "pmm") {
       # This can be programmed a lot better possibly with custom method outcome that would
@@ -185,20 +229,24 @@ nonprob_mi <- function(outcome,
 
         if (isTRUE(control_inference$nn_exact_se) & method_outcome %in% c("pmm", "nn")) {
           ## mini-bootstrap as suggested in the MI-PMM paper
-          boot_obj_comp2 <- outcome_method(y_nons = y_nons,
-                                           X_nons = X_nons,
-                                           X_rand = X_rand,
-                                           svydesign = svydesign,
-                                           weights=case_weights,
-                                           family_outcome=family_outcome,
-                                           start_outcome=start_outcome,
-                                           vars_selection=vars_selection,
-                                           pop_totals=pop_totals_,
-                                           pop_size=pop_size,
-                                           control_outcome=control_outcome,
-                                           control_inference=control_inference,
-                                           verbose=verbose,
-                                           se=se)
+          comp2_args <- list(y_nons = y_nons,
+                             X_nons = X_nons,
+                             X_rand = X_rand,
+                             svydesign = svydesign,
+                             weights=case_weights,
+                             family_outcome=family_outcome,
+                             start_outcome=start_outcome,
+                             vars_selection=vars_selection,
+                             pop_totals=pop_totals_,
+                             pop_size=pop_size,
+                             control_outcome=control_outcome,
+                             control_inference=control_inference,
+                             verbose=verbose,
+                             se=se)
+          if (method_outcome == "nn" && !is.null(nn_matches)) {
+            comp2_args$nn_matches <- nn_matches
+          }
+          boot_obj_comp2 <- do.call(outcome_method, comp2_args)
 
           comp2 <- boot_obj_comp2$var_nonprob
         } else {

--- a/inst/tinytest/test_nn_cache.R
+++ b/inst/tinytest/test_nn_cache.R
@@ -1,0 +1,39 @@
+local({
+  assign(".nonprobsvy_test_nn2_calls", 0L, envir = .GlobalEnv)
+  trace(
+    "nn2",
+    where = asNamespace("RANN"),
+    tracer = quote(assign(
+      ".nonprobsvy_test_nn2_calls",
+      get(".nonprobsvy_test_nn2_calls", envir = .GlobalEnv) + 1L,
+      envir = .GlobalEnv
+    )),
+    print = FALSE
+  )
+  on.exit({
+    untrace("nn2", where = asNamespace("RANN"))
+    rm(".nonprobsvy_test_nn2_calls", envir = .GlobalEnv)
+  }, add = TRUE)
+
+  toy_svy <- survey::svydesign(
+    ids = ~1,
+    weights = ~w,
+    data = data.frame(x = c(0.5, 4), w = c(2, 3))
+  )
+
+  multi_outcome_nn <- nonprob(
+    outcome = y1 + y2 ~ x,
+    data = data.frame(x = c(0, 2, 5), y1 = c(1, 4, 9), y2 = c(3, 6, 12)),
+    svydesign = toy_svy,
+    method_outcome = "nn",
+    control_outcome = control_out(k = 2),
+    se = FALSE
+  )
+
+  expect_equal(get(".nonprobsvy_test_nn2_calls", envir = .GlobalEnv), 2L)
+  expect_equal(
+    unname(multi_outcome_nn$output$mean),
+    c(4.9, 7.2),
+    tolerance = 1e-12
+  )
+})

--- a/man/method_nn.Rd
+++ b/man/method_nn.Rd
@@ -18,7 +18,8 @@ method_nn(
   control_outcome = control_out(),
   control_inference = control_inf(),
   verbose = FALSE,
-  se = TRUE
+  se = TRUE,
+  nn_matches = NULL
 )
 }
 \arguments{
@@ -49,6 +50,10 @@ method_nn(
 \item{verbose}{parameter passed from the main \code{nonprob} function}
 
 \item{se}{whether standard errors should be calculated}
+
+\item{nn_matches}{optional precomputed nearest-neighbour search results for
+internal reuse across outcomes. If supplied, it should be a list with
+\code{rand} and \code{nons} entries from \link[RANN:nn2]{RANN::nn2()}.}
 }
 \value{
 an \code{nonprob_method} class which is a \code{list} with the following entries


### PR DESCRIPTION
## Summary
- cache NN search results in multi-outcome NN mass imputation when the covariate matrices and NN controls are unchanged
- let method_nn consume precomputed rand/nons RANN::nn2 results while preserving standalone behavior
- add a tinytest regression that traces RANN::nn2 and expects two searches across two outcomes

Fixes #104

## Tests
- Rscript -e "devtools::load_all(quiet = TRUE); tinytest::run_test_file('inst/tinytest/test_nn_cache.R')"
- Rscript -e "devtools::load_all(quiet = TRUE); tinytest::run_test_dir('inst/tinytest')"
- R CMD check --no-manual --no-build-vignettes nonprobsvy_0.2.3.tar.gz (1 warning: survey/Matrix/survival built under R 4.4.3 while check ran under R 4.4.2)